### PR TITLE
feat: allow shelf urls to be processed

### DIFF
--- a/goodreads_scraper/scrape.py
+++ b/goodreads_scraper/scrape.py
@@ -1,7 +1,7 @@
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
 from goodreads_scraper.utils import (
-    create_shelf_url,
+    create_read_shelf_url,
     create_read_page,
     parse_infinite_status,
     setup_browser,
@@ -9,6 +9,7 @@ from goodreads_scraper.utils import (
     read_books_fast,
     page_wait,
     cleanup_birthplace,
+    is_goodreads_shelf
 )
 from selenium.webdriver.chrome.webdriver import WebDriver
 from selenium.webdriver.support.ui import WebDriverWait
@@ -93,7 +94,7 @@ def scrape_shelf(url: str) -> List[Dict[str, Any]]:
     return book_list
 
 
-def process_profile(user_profile: str) -> List[Dict[str, str]]:
+def process_goodreads_url(url: str) -> List[Dict[str, str]]:
     """Main function for the scraping.
     Will get a url, validate it as a GR profile and, if valid, create the shelf url to then be scraped.
     Returns the list of books in that shelf.
@@ -107,11 +108,12 @@ def process_profile(user_profile: str) -> List[Dict[str, str]]:
     Returns:
         List[Dict[str, str]]: List of dictionaries where each is a book extracted from the shelf and processed accordingly.
     """
-    valid_profile = is_goodreads_profile(user_profile)
-    if not valid_profile:
-        raise ValueError("Your URL was not a valid Goodreads profile.")
-    read_shelf_url = create_shelf_url(user_profile)
-    user_books = scrape_shelf(read_shelf_url)
+    valid_profile = is_goodreads_profile(url)
+    valid_shelf = is_goodreads_shelf(url)
+    if not valid_profile and not valid_shelf:
+        raise ValueError("Your URL was not a valid Goodreads URL to scrape.")
+    shelf_url = create_read_shelf_url(url) if not valid_shelf else url
+    user_books = scrape_shelf(shelf_url)
     return user_books
 
 
@@ -152,5 +154,5 @@ def scrape_gr_author(url: str) -> tuple[str | None, str | None]:
 
 if __name__ == "__main__":
     user_profile = "https://www.goodreads.com/user/show/71341746-tamir-einhorn-salem"
-    books = process_profile(user_profile)
+    books = process_goodreads_url(user_profile)
     print(books)

--- a/goodreads_scraper/utils.py
+++ b/goodreads_scraper/utils.py
@@ -331,4 +331,15 @@ def cleanup_birthplace(birthplace: str | None) -> str | None:
 
 
 def is_goodreads_shelf(url: str) -> bool:
-    pass
+    """Verifies if a provided URL is a proper Goodreads shelf URL.
+    Calls upon is_valid_goodreads_url for good measure.
+
+    Args:
+        url (str): String representing an URL to be checked.
+
+    Returns:
+        bool: True if it's a shelf in GR, False otherwise.
+    """
+    # A URL is a profile if it's a valid Goodreads URL and follows the Regex for having user/show/{USER_ID}-(username)
+    pattern = r"^https:\/\/www\.goodreads\.com\/review\/list\/\d+.*$"
+    return bool(re.match(pattern, url)) and is_valid_goodreads_url(url)

--- a/goodreads_scraper/utils.py
+++ b/goodreads_scraper/utils.py
@@ -61,7 +61,7 @@ def is_goodreads_profile(url: str) -> bool:
     return bool(re.match(pattern, url)) and is_valid_goodreads_url(url)
 
 
-def create_shelf_url(profile_url: str) -> str:
+def create_read_shelf_url(profile_url: str) -> str:
     """From a valid GR profile url, get the read shelf URL.
     Although this does work starting from the read shelf itself, it's better to just always use it with the user's profile.
     Some shelves will add the username to the URL itself, making this not ideal to work with. Keep it simple for now.

--- a/goodreads_scraper/utils.py
+++ b/goodreads_scraper/utils.py
@@ -328,3 +328,7 @@ def cleanup_birthplace(birthplace: str | None) -> str | None:
             return raw_country[4:]
         return raw_country
     return None
+
+
+def is_goodreads_shelf(url: str) -> bool:
+    pass

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -57,8 +57,8 @@ def test_process_profile():
 @pytest.mark.integration
 def test_process_profile_with_shelf_url():
     # Run the scraper
-    user_profile = "https://www.goodreads.com/review/list/71341746?shelf=read"
-    actual_results = process_goodreads_url(user_profile)
+    url = "https://www.goodreads.com/review/list/71341746?shelf=read"
+    actual_results = process_goodreads_url(url)
 
     # Check if the number of books matches the expectation
     assert len(actual_results) >= 300
@@ -69,7 +69,11 @@ def test_process_profile_with_shelf_url():
     for title in ["Les Visages", "O poderoso chefão"]:
         assert title in actual_titles
 
-
+@pytest.mark.integration
+def test_process_profile_invalid_url():
+    url = "https://www.goodreads.com/book/show/17899167-o-quarto-de-jacob"
+    with pytest.raises(ValueError):
+        process_goodreads_url(url=url)
 
 @pytest.mark.integration
 def test_scrape_saved_shelf():

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -54,6 +54,22 @@ def test_process_profile():
     for title in ["Les Visages", "O poderoso chefão"]:
         assert title in actual_titles
 
+@pytest.mark.integration
+def test_process_profile_with_shelf_url():
+    # Run the scraper
+    user_profile = "https://www.goodreads.com/review/list/71341746?shelf=read"
+    actual_results = process_profile(user_profile)
+
+    # Check if the number of books matches the expectation
+    assert len(actual_results) >= 300
+
+    # Verify that the known titles are in the actual results
+    actual_titles = [book["title"] for book in actual_results]
+
+    for title in ["Les Visages", "O poderoso chefão"]:
+        assert title in actual_titles
+
+
 
 @pytest.mark.integration
 def test_scrape_saved_shelf():

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -40,7 +40,7 @@ def test_scrape_live_shelf():
 
 
 @pytest.mark.integration
-def test_scrape_another_live_shelf():
+def test_process_profile():
     # Run the scraper
     user_profile = "https://www.goodreads.com/user/show/71341746-tamir-einhorn-salem"
     actual_results = process_profile(user_profile)

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,6 +1,6 @@
 import pytest
 from typing import Tuple
-from goodreads_scraper.scrape import scrape_shelf, process_profile, scrape_gr_author
+from goodreads_scraper.scrape import scrape_shelf, process_goodreads_url, scrape_gr_author
 from pathlib import Path
 
 fixture_path = Path(__file__).parent.joinpath("test_assets", "example_goodreads.html")
@@ -43,7 +43,7 @@ def test_scrape_live_shelf():
 def test_process_profile():
     # Run the scraper
     user_profile = "https://www.goodreads.com/user/show/71341746-tamir-einhorn-salem"
-    actual_results = process_profile(user_profile)
+    actual_results = process_goodreads_url(user_profile)
 
     # Check if the number of books matches the expectation
     assert len(actual_results) >= 300
@@ -58,7 +58,7 @@ def test_process_profile():
 def test_process_profile_with_shelf_url():
     # Run the scraper
     user_profile = "https://www.goodreads.com/review/list/71341746?shelf=read"
-    actual_results = process_profile(user_profile)
+    actual_results = process_goodreads_url(user_profile)
 
     # Check if the number of books matches the expectation
     assert len(actual_results) >= 300

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -156,7 +156,7 @@ def test_browser_setup(chrome_browser):
         ("https:/www.goodreads.com/user/show/1", False),
         ("https://www.goodreads.com/user/show/1 with space", False),
         ("https://www.goodreads.com/user/show/abc", False),
-        ("https://www.goodreads.com/user/show/71341746-tamir-einhorn-salem", True),
+        ("https://www.goodreads.com/user/show/71341746-tamir-einhorn-salem", False),
         ("https://www.goodreads.com/review/list/1?shelf=nonfiction", True),
         ("https://www.goodreads.com/review/list/1?page=10&shelf=nonfiction", True),
         ("https://www.goodreads.com/review/list/1", True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,13 +4,13 @@ from goodreads_scraper.utils import (
     create_shelf_url,
     extract_hidden_td,
     extract_author_id,
-    is_goodreads_shelf
+    is_goodreads_shelf,
+    setup_browser
 )
 import pytest
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 import os
-from goodreads_scraper.utils import extract_hidden_td, setup_browser
 
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -108,7 +108,7 @@ def test_extract_hidden_td(chrome_browser):
 
     # Wait for the table to be present
     wait = WebDriverWait(chrome_browser, 10)
-    table = wait.until(EC.presence_of_element_located((By.TAG_NAME, "table")))
+    wait.until(EC.presence_of_element_located((By.TAG_NAME, "table")))
 
     # Find the first 'tr' element in the table
     row = chrome_browser.find_element(By.CSS_SELECTOR, "tr")
@@ -137,7 +137,7 @@ def test_extract_author_id(url, expected_id):
 
 
 def test_browser_setup(chrome_browser):
-    assert type(chrome_browser) == type(setup_browser())
+    assert type(chrome_browser) is type(setup_browser())
 
 @pytest.mark.parametrize(
     "url,expected",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -145,9 +145,9 @@ def test_browser_setup(chrome_browser):
         ("https://www.goodreads.com/book/show/12345", False),
         ("https://www.example.com", False),
         ("not a url", False),
-        ("https://www.goodreads.com/user/show/1", True),
-        ("https://www.goodreads.com/user/show/300", True),
-        ("https://www.goodreads.com/review/list/300?shelf=read", False),
+        ("https://www.goodreads.com/user/show/1", False),
+        ("https://www.goodreads.com/user/show/300", False),
+        ("https://www.goodreads.com/review/list/300?shelf=read", True),
         ("https://www.goodreads.com/user/show/1?param=value", False),
         ("https://www.goodreads.com/user/show/", False),
         ("https://www.goodreads.com/user", False),
@@ -157,6 +157,9 @@ def test_browser_setup(chrome_browser):
         ("https://www.goodreads.com/user/show/1 with space", False),
         ("https://www.goodreads.com/user/show/abc", False),
         ("https://www.goodreads.com/user/show/71341746-tamir-einhorn-salem", True),
+        ("https://www.goodreads.com/review/list/1?shelf=nonfiction", True),
+        ("https://www.goodreads.com/review/list/1?page=10&shelf=nonfiction", True),
+        ("https://www.goodreads.com/review/list/1", True)
     ],
 )
 def test_is_goodreads_shelf(url: str, expected: bool

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from goodreads_scraper.utils import (
     create_shelf_url,
     extract_hidden_td,
     extract_author_id,
+    is_goodreads_shelf
 )
 import pytest
 from selenium import webdriver
@@ -137,3 +138,27 @@ def test_extract_author_id(url, expected_id):
 
 def test_browser_setup(chrome_browser):
     assert type(chrome_browser) == type(setup_browser())
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://www.goodreads.com/book/show/12345", False),
+        ("https://www.example.com", False),
+        ("not a url", False),
+        ("https://www.goodreads.com/user/show/1", True),
+        ("https://www.goodreads.com/user/show/300", True),
+        ("https://www.goodreads.com/review/list/300?shelf=read", False),
+        ("https://www.goodreads.com/user/show/1?param=value", False),
+        ("https://www.goodreads.com/user/show/", False),
+        ("https://www.goodreads.com/user", False),
+        ("https://profile.goodreads.com/user/show/1", False),
+        ("https://www.goodreads.com/user/show/1#details", False),
+        ("https:/www.goodreads.com/user/show/1", False),
+        ("https://www.goodreads.com/user/show/1 with space", False),
+        ("https://www.goodreads.com/user/show/abc", False),
+        ("https://www.goodreads.com/user/show/71341746-tamir-einhorn-salem", True),
+    ],
+)
+def test_is_goodreads_shelf(url: str, expected: bool
+                            ) -> None:
+    assert is_goodreads_shelf(url) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 from goodreads_scraper.utils import (
     is_valid_goodreads_url,
     is_goodreads_profile,
-    create_shelf_url,
+    create_read_shelf_url,
     extract_hidden_td,
     extract_author_id,
     is_goodreads_shelf,
@@ -81,7 +81,7 @@ def test_profile_url(url: str, expected: bool):
     ],
 )
 def test_read_shelf_fetch(profile_url: str, expected: str):
-    assert create_shelf_url(profile_url=profile_url) == expected
+    assert create_read_shelf_url(profile_url=profile_url) == expected
 
 
 # Fixture to initialize WebDriver


### PR DESCRIPTION
If a user passes a shelf URL, they should not have any troubles with the scraping. This ensures this happens while also testing more stuff in detail.